### PR TITLE
core: add 'capslock' to non_symbols

### DIFF
--- a/xkbgroup/core.py
+++ b/xkbgroup/core.py
@@ -124,7 +124,7 @@ class XKeyboard:
 
     # Fields with default values
 
-    non_symbols = {"pc", "inet", "group", "terminate"}
+    non_symbols = {"capslock", "pc", "inet", "group", "terminate"}
 
 
     # Main methods
@@ -493,7 +493,8 @@ def _parse_symbols(symbols_str, non_symbols, default_index=0):
             symboldata_list.append(symboldata)
 
     indices = [symdata.index for symdata in symboldata_list]
-    assert len(indices) == len(set(indices))    # No doubles
+    assert len(indices) == len(set(indices)), ("Duplicate index in %r" %
+                                               symboldata_list)
 
     return symboldata_list
 


### PR DESCRIPTION
Some users like to add special rules for caps lock. We should support
that.

Also, give a more informative error message when the assert finds
duplicate indexes.