### PR TITLE
add cli wrapper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -241,3 +241,5 @@ There are also complementary files:
 
 * ``xkbgroup/xkb.py`` — the output of the above script, usable for Xlib
   development under Python.
+
+* ``cli/xkb-group.py`` — python cli wrapper. Resembles https://github.com/ierton/xkb-switch

--- a/cli/xkb-group.py
+++ b/cli/xkb-group.py
@@ -1,0 +1,26 @@
+import argparse
+import sys
+from xkbgroup import XKeyboard
+
+def main(args):
+    xkb = XKeyboard()
+    if args.l:
+        print("\n".join(xkb.groups_names))
+    elif args.p:
+        print(xkb.group_name)
+    elif args.s:
+        xkb.group_name = args.s
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    command_group = parser.add_mutually_exclusive_group()
+    command_group.add_argument("-l", help="list layout groups", action='store_true')
+    command_group.add_argument("-p", help="show current layout groups", action='store_true')
+    command_group.add_argument("-s", help="set current layout groups", type=str)
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(1)
+
+    args = parser.parse_args(sys.argv[1:])
+    main(args)


### PR DESCRIPTION
add wrapper to expose simple layout switching from cli. see https://github.com/ierton/xkb-switch for alternative, which doesn't work well with layouts defined through `xkbcomp`.